### PR TITLE
DD-1438 dd-manage-deposits improvements fixes for DD-1419 - Part 1

### DIFF
--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -18,7 +18,7 @@ depositBoxes:
   - /var/opt/dans.knaw.nl/tmp/auto-ingest/outbox/failed
   - /var/opt/dans.knaw.nl/tmp/sword2-uploads
 
-pollingInterval: 5000
+pollingInterval: 50
 
 depositPropertiesDatabase:
   driverClass: org.postgresql.Driver

--- a/src/main/java/nl/knaw/dans/managedeposit/core/service/DepositStatusUpdater.java
+++ b/src/main/java/nl/knaw/dans/managedeposit/core/service/DepositStatusUpdater.java
@@ -44,11 +44,8 @@ public class DepositStatusUpdater {
         if (dp.isPresent()) {
             // The 'move deposit' action is processed in two steps: 1. `create` deposit in the new location; 2. `delete` it from the old location.
             // Update the location column.
-            Path depositLocationFolder = Path.of(depositPropertiesFile.getParentFile().getParentFile().getAbsolutePath());
-            Optional<Integer> updatedNumber = depositPropertiesDAO.updateDepositLocation(dp.get().getDepositId(), depositLocationFolder);
-            if (updatedNumber.isPresent())
-                log.debug("onCreateDeposit - `location` of deposit '{}' has been updated to '{}' ", dp.get().getDepositId(), depositLocationFolder);
-        }
+            onChangeDeposit(depositPropertiesFile);
+            }
         else {
             Optional<DepositProperties> dpObject = depositPropertiesAssembler.assembleObject(depositPropertiesFile, false);
             dpObject.ifPresent(depositPropertiesDAO::save);


### PR DESCRIPTION
Fixes DD-1438 dd-manage-deposits: Fix problems found DD-1419

# Description of changes
These two changes are important improvements.
  - Using smaller time interval range to check the inbox and outbox folders
  - Check de content of the deposit.properties file every time when they are moved
  One other improvements will follow soon.
# How to test

# Related PRs

(Add links)

*

# Notify


@DANS-KNAW/core-systems
