### PR TITLE
DD-1492 dd-manage-deposits improvements fixes for DD-1419 - Part 2 di…

### DIFF
--- a/src/main/java/nl/knaw/dans/managedeposit/core/service/DepthFileFilter.java
+++ b/src/main/java/nl/knaw/dans/managedeposit/core/service/DepthFileFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.managedeposit.core.service;
+
+import org.apache.commons.io.filefilter.AbstractFileFilter;
+
+import java.io.File;
+import java.nio.file.Path;
+
+public class DepthFileFilter extends AbstractFileFilter {
+    private final Path baseFolder;
+    private final int depthLimit;
+
+    public DepthFileFilter(Path baseFolder, int depthLimit) {
+        this.baseFolder = baseFolder;
+        this.depthLimit = depthLimit;
+
+    }
+
+    public boolean accept(File file) {
+        Path parent = file.toPath();
+        for (int depth = 0; depth < this.depthLimit; depth++)
+            parent = parent.getParent();
+        if (parent.endsWith(this.baseFolder))
+            return true;
+
+        return false;
+    }
+}

--- a/src/main/java/nl/knaw/dans/managedeposit/core/service/IngestPathMonitor.java
+++ b/src/main/java/nl/knaw/dans/managedeposit/core/service/IngestPathMonitor.java
@@ -47,13 +47,13 @@ public class IngestPathMonitor extends FileAlterationListenerAdaptor implements 
     }
 
     private void startMonitors() throws Exception {
-        IOFileFilter directories = FileFilterUtils.and(FileFilterUtils.directoryFileFilter(), HiddenFileFilter.VISIBLE);
-        IOFileFilter files = FileFilterUtils.and(FileFilterUtils.fileFileFilter(), FileFilterUtils.nameFileFilter("deposit.properties", IOCase.INSENSITIVE));
-        IOFileFilter filter = FileFilterUtils.or(directories, files);
-
-        log.info("Starting 'IngestPathMonitor', file filter: deposit.properties");
+        log.info("Starting 'IngestPathMonitor', file filter: deposit.properties, directory depth: only first child of the base folder");
 
         for (Path folder : toMonitorPaths) {
+            IOFileFilter directories = FileFilterUtils.and(FileFilterUtils.directoryFileFilter(), new DepthFileFilter(folder, 1));
+            IOFileFilter files = FileFilterUtils.and(FileFilterUtils.fileFileFilter(), FileFilterUtils.nameFileFilter("deposit.properties", IOCase.INSENSITIVE));
+            IOFileFilter filter = FileFilterUtils.or(directories, files);
+
             FileAlterationObserver observer = new FileAlterationObserver(folder.toFile(), filter);
 
             observer.addListener(this);


### PR DESCRIPTION
…rectory search depth limit

Fixes DD-1438 dd-manage-deposits: Fix problems found DD-1419

# Description of changes
  Manage deposit module should only check and search in the first folder of a dataset for deposit.properties file and not in the child folders. The depth search folder is set to 1.

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
