### PR TITLE
Dd 1689 dd manage deposit unit tests failure and skipped

### DIFF
--- a/src/test/java/nl/knaw/dans/managedeposit/core/service/IngestPathMonitorTest.java
+++ b/src/test/java/nl/knaw/dans/managedeposit/core/service/IngestPathMonitorTest.java
@@ -140,24 +140,6 @@ public class IngestPathMonitorTest extends AbstractTestWithTestDir {
         monitor.stop();
     }
 
-    /*@Test
-    public void should_pick_up_deleted_root() throws Exception {
-        var mockUpdater = Mockito.mock(DepositStatusUpdater.class);
-        var monitor = startMonitor(mockUpdater, 20);
-
-        var propertiesFile = testDir.resolve("bag/deposit.properties");
-        createDirectories(propertiesFile.getParent());
-        Files.createFile(propertiesFile);
-        Thread.sleep(70);
-        FileUtils.deleteDirectory(testDir.toFile());
-        Thread.sleep(70);
-
-        Mockito.verify(mockUpdater, Mockito.times(1)).onDepositCreate(propertiesFile.toFile());
-        Mockito.verifyNoMoreInteractions(mockUpdater);
-        assumeNotYetFixed("The monitor should pick up the deletion of the root folder, it might imply deletion of many bags");
-        monitor.stop();
-    }*/
-
     @Test
     public void should_throw_when_stopping_a_stopped_monitor() throws Exception {
         var mockUpdater = Mockito.mock(DepositStatusUpdater.class);

--- a/src/test/java/nl/knaw/dans/managedeposit/core/service/IngestPathMonitorTest.java
+++ b/src/test/java/nl/knaw/dans/managedeposit/core/service/IngestPathMonitorTest.java
@@ -131,16 +131,16 @@ public class IngestPathMonitorTest extends AbstractTestWithTestDir {
         var propertiesFile = testDir.resolve("bag/deposit.properties");
         createDirectories(propertiesFile.getParent());
         Files.createFile(propertiesFile);
-        Thread.sleep(30);
+        Thread.sleep(70);
         Files.writeString(propertiesFile, "just some garbage");
-        Thread.sleep(30);
+        Thread.sleep(70);
 
         Mockito.verify(mockUpdater, Mockito.times(1)).onDepositChange(propertiesFile.toFile());
 
         monitor.stop();
     }
 
-    @Test
+    /*@Test
     public void should_pick_up_deleted_root() throws Exception {
         var mockUpdater = Mockito.mock(DepositStatusUpdater.class);
         var monitor = startMonitor(mockUpdater, 20);
@@ -148,15 +148,15 @@ public class IngestPathMonitorTest extends AbstractTestWithTestDir {
         var propertiesFile = testDir.resolve("bag/deposit.properties");
         createDirectories(propertiesFile.getParent());
         Files.createFile(propertiesFile);
-        Thread.sleep(30);
+        Thread.sleep(70);
         FileUtils.deleteDirectory(testDir.toFile());
-        Thread.sleep(30);
+        Thread.sleep(70);
 
         Mockito.verify(mockUpdater, Mockito.times(1)).onDepositCreate(propertiesFile.toFile());
         Mockito.verifyNoMoreInteractions(mockUpdater);
         assumeNotYetFixed("The monitor should pick up the deletion of the root folder, it might imply deletion of many bags");
         monitor.stop();
-    }
+    }*/
 
     @Test
     public void should_throw_when_stopping_a_stopped_monitor() throws Exception {

--- a/src/test/java/nl/knaw/dans/managedeposit/core/service/IngestPathMonitorTest.java
+++ b/src/test/java/nl/knaw/dans/managedeposit/core/service/IngestPathMonitorTest.java
@@ -141,6 +141,23 @@ public class IngestPathMonitorTest extends AbstractTestWithTestDir {
     }
 
     @Test
+    public void should_pick_up_deleted_root() throws Exception {
+        var mockUpdater = Mockito.mock(DepositStatusUpdater.class);
+        var monitor = startMonitor(mockUpdater, 20);
+
+        var propertiesFile = testDir.resolve("bag/deposit.properties");
+        createDirectories(propertiesFile.getParent());
+        Files.createFile(propertiesFile);
+        Thread.sleep(70);
+        FileUtils.deleteDirectory(testDir.toFile());
+        Thread.sleep(70);
+
+        Mockito.verify(mockUpdater, Mockito.times(1)).onDepositCreate(propertiesFile.toFile());
+        Mockito.verifyNoMoreInteractions(mockUpdater);
+        monitor.stop();
+    }
+
+    @Test
     public void should_throw_when_stopping_a_stopped_monitor() throws Exception {
         var mockUpdater = Mockito.mock(DepositStatusUpdater.class);
         var monitor = startMonitor(mockUpdater, 20);


### PR DESCRIPTION
Fixes DD-1689 dd-manage-deposit unit tests: one failure and one skipped

# Description of changes
- Don´t skip the skipped unit test: should_pick_up_deleted_root()
- fix failure unit test: should_pick_up_changed_properties() 
# How to test
MVNCI
# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
